### PR TITLE
Add custom ID support to backend

### DIFF
--- a/backend/models/document.go
+++ b/backend/models/document.go
@@ -20,10 +20,10 @@ type Document struct {
 // NewDocument creates a document object given the path of the file that
 // has already been downloaded and the time this file should exist on the
 // server.
-func NewDocument(fileId string, fileName string, extension string, expirationTime time.Time) *Document {
+func NewDocument(fileId, fsFileName, extension string, expirationTime time.Time) *Document {
 	return &Document{
 		FileId:         fileId,
-		FileName:       fileName,
+		FileName:       fsFileName,
 		Extension:      extension,
 		ExpirationTime: expirationTime,
 	}

--- a/backend/models/document.go
+++ b/backend/models/document.go
@@ -12,6 +12,7 @@ import (
 // server.
 type Document struct {
 	FileId         string    // The location of the file
+	FileName       string    // The name of the file (on the server)
 	Extension      string    // The extension of the file
 	ExpirationTime time.Time // When the file should be deleted from the server
 }
@@ -19,14 +20,15 @@ type Document struct {
 // NewDocument creates a document object given the path of the file that
 // has already been downloaded and the time this file should exist on the
 // server.
-func NewDocument(fileId string, extension string, expirationTime time.Time) *Document {
+func NewDocument(fileId string, fileName string, extension string, expirationTime time.Time) *Document {
 	return &Document{
 		FileId:         fileId,
+		FileName:       fileName,
 		Extension:      extension,
 		ExpirationTime: expirationTime,
 	}
 }
 
 func (d *Document) GetPath() string {
-	return filepath.Join(setting.ServerSetting.DownloadPath, d.FileId+d.Extension)
+	return filepath.Join(setting.ServerSetting.DownloadPath, d.FileName+d.Extension)
 }

--- a/backend/routers/router_test.go
+++ b/backend/routers/router_test.go
@@ -22,19 +22,27 @@ func init() {
 	setting.Setup("../conf/app.ini")
 }
 
-func CreateMultiPartFormFile(t *testing.T, file io.Reader, filename string, contents []byte) (io.Reader, string) {
+func CreateMultiPartFormFile(t *testing.T, file io.Reader, filename, customId string, contents []byte) (io.Reader, string) {
 	var b bytes.Buffer
 	var fw io.Writer
 	w := multipart.NewWriter(&b)
+	// write expiration
 	err := w.WriteField("expiration", strconv.FormatInt(time.Now().Add(time.Minute).UnixMilli(), 10))
+	// write file
 	if err != nil {
 		t.Fatalf("Failed to write expiration to multipart: %v", err)
 	}
-	if fw, err = w.CreateFormFile("file", "test.txt"); err != nil {
+	if fw, err = w.CreateFormFile("file", filename); err != nil {
 		t.Fatalf("Failed to create file in multipart: %v", err)
 	}
 	if _, err := fw.Write(contents); err != nil {
 		t.Fatalf("Failed to write contents to writer: %v", err)
+	}
+	// write custom id
+	if customId != "" {
+		if err := w.WriteField("custom_id", customId); err != nil {
+			t.Fatalf("Failed to write custom ID to multipart: %v", err)
+		}
 	}
 	w.Close()
 	return &b, w.FormDataContentType()
@@ -44,13 +52,15 @@ func TestApp(t *testing.T) {
 	router := InitRouter()
 	contents := []byte("hello world")
 
-	content, contentType := CreateMultiPartFormFile(t, nil, "/arbitrary/path/test.txt", contents)
+	// upload file
+	content, contentType := CreateMultiPartFormFile(t, nil, "/arbitrary/path/test.txt", "", contents)
 
 	rec := httptest.NewRecorder()
 	req, _ := http.NewRequest("POST", "/upload", content)
 	req.Header.Set("Content-Type", contentType)
 	router.ServeHTTP(rec, req)
 
+	// response should be ok
 	assert.Equal(t, http.StatusOK, rec.Code)
 	var res v1.UploadResponse
 	err := json.Unmarshal(rec.Body.Bytes(), &res)
@@ -58,11 +68,13 @@ func TestApp(t *testing.T) {
 	assert.NotEqual(t, "", res.FileId, "Should have non-empty file ID")
 	assert.True(t, time.UnixMilli(res.Expiration).After(time.Now()), "Expiration should be in future")
 
+	// file should exist on system
 	fp := filepath.Join(setting.ServerSetting.DownloadPath, res.FileId+".txt")
 	actual, err := os.ReadFile(fp)
 	assert.NoError(t, err, "File should exist on system")
 	assert.Equal(t, contents, actual, "Contents on system should match")
 
+	// download file
 	fileReq := v1.FileRequest{FileId: res.FileId}
 	var fileReqBody []byte
 	if fileReqBody, err = json.Marshal(fileReq); err != nil {
@@ -73,6 +85,7 @@ func TestApp(t *testing.T) {
 	req, _ = http.NewRequest("POST", "/download", bytes.NewBuffer(fileReqBody))
 	router.ServeHTTP(rec, req)
 
+	// download should be correct
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Equal(t, contents, rec.Body.Bytes(), "File contents should match")
 }
@@ -90,14 +103,16 @@ func TestMissingFileUpload(t *testing.T) {
 func TestFileNameNoExtUpload(t *testing.T) {
 	router := InitRouter()
 
+	// upload file with no extension in name
 	contents := []byte("hello world")
-	content, contentType := CreateMultiPartFormFile(t, nil, "test", contents)
+	content, contentType := CreateMultiPartFormFile(t, nil, "test", "", contents)
 
 	rec := httptest.NewRecorder()
 	req, _ := http.NewRequest("POST", "/upload", content)
 	req.Header.Set("Content-Type", contentType)
 	router.ServeHTTP(rec, req)
 
+	// response should be ok
 	assert.Equal(t, http.StatusOK, rec.Code)
 
 	var res v1.UploadResponse
@@ -105,6 +120,7 @@ func TestFileNameNoExtUpload(t *testing.T) {
 	assert.NoError(t, err, "Download response should deserialize")
 	assert.NotEqual(t, "", res.FileId, "Should have non-empty file ID")
 
+	// downloading it should be ok
 	fileReq := v1.FileRequest{FileId: res.FileId}
 	var fileReqBody []byte
 	if fileReqBody, err = json.Marshal(fileReq); err != nil {
@@ -117,4 +133,47 @@ func TestFileNameNoExtUpload(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Equal(t, contents, rec.Body.Bytes(), "File contents should match")
+}
+
+func TestCustomId(t *testing.T) {
+	router := InitRouter()
+
+	// upload with custom ID
+	contents := []byte("hello world")
+	content, contentType := CreateMultiPartFormFile(t, nil, "test.txt", "custom", contents)
+
+	rec := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/upload", content)
+	req.Header.Set("Content-Type", contentType)
+	router.ServeHTTP(rec, req)
+
+	// response should be ok
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var res v1.UploadResponse
+	err := json.Unmarshal(rec.Body.Bytes(), &res)
+	assert.NoError(t, err, "Download response should deserialize")
+	assert.Equal(t, "custom", res.FileId, "Should have non-empty file ID")
+
+	fileReq := v1.FileRequest{FileId: res.FileId}
+	var fileReqBody []byte
+	if fileReqBody, err = json.Marshal(fileReq); err != nil {
+		t.Fatalf("Failed to serialize file request: %v", err)
+	}
+
+	// downloading it should be ok
+	rec = httptest.NewRecorder()
+	req, _ = http.NewRequest("POST", "/download", bytes.NewBuffer(fileReqBody))
+	router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, contents, rec.Body.Bytes(), "File contents should match")
+
+	// attempting to upload with the same custom ID should fail
+	rec = httptest.NewRecorder()
+	req, _ = http.NewRequest("POST", "/upload", content)
+	req.Header.Set("Content-Type", contentType)
+	router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code, "Request should fail")
 }

--- a/backend/routers/v1/upload.go
+++ b/backend/routers/v1/upload.go
@@ -44,16 +44,35 @@ func UploadFile(c *gin.Context) {
 
 	}
 
-	extension := filepath.Ext(file.Filename)
-	fileId := uuid.New().String()
-
 	// Simulating saving file to store
 	// TODO: Move logic for downloading file
 	// into another method.
 	store := c.MustGet("store").(*services.Store)
+
+	extension := filepath.Ext(file.Filename)
+	fileName := uuid.New().String()
+	fileId := fileName
+	if customId := c.PostForm("custom_id"); customId != "" {
+		fileId = customId
+	}
+
+	if len(fileId) > 255 || len(fileId) < 4 {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{
+			"message": "File ID length is out of bounds",
+		})
+		return
+	}
+
+	if store.GetDocFromStore(fileId) != nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{
+			"message": "File with this ID exists",
+		})
+		return
+	}
+
 	// TODO: Using 10 minutes as default duration. This should be a value we
 	// receive in the frontend and access through the gin.Context.
-	doc := models.NewDocument(fileId, extension, expirationTime)
+	doc := models.NewDocument(fileId, fileName, extension, expirationTime)
 	store.AddToStore(doc)
 
 	// Save the file

--- a/backend/services/store_test.go
+++ b/backend/services/store_test.go
@@ -15,7 +15,7 @@ func init() {
 }
 
 func TestStore(t *testing.T) {
-	doc := models.NewDocument("test1", ".txt", time.Now().Add(time.Minute))
+	doc := models.NewDocument("test1", "test1", ".txt", time.Now().Add(time.Minute))
 	if _, err := os.Create(doc.GetPath()); err != nil {
 		t.Fatalf("Error creating file: %v", err)
 	}


### PR DESCRIPTION
Allows the user to specify a custom ID that the file can be retrieved with. For safety, we still use the UUID for file storage to prevent directory traversal.